### PR TITLE
fix(prettier): bracket same line rule 2.4.*

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
   jsxSingleQuote: false,
   trailingComma: 'es5',
   bracketSpacing: true,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   arrowParens: 'always',
   overrides: [
     {


### PR DESCRIPTION
Starting in Prettier 2.4.0, `jsxBracketSameLine` is deprecated and will warn in the console when running prettier:
> [warn] jsxBracketSameLine is deprecated.

This PR updates the option to the new `bracketSameLine`. The rule is `false` by default: https://prettier.io/docs/en/options.html#bracket-line. 

Fixes: #2