### PR TITLE
v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/prettier-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Prettier config for Ionic and Capacitor",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Included in this release
- [chore(options): replace jsxBracketSameLine with bracketSameLine](https://github.com/ionic-team/prettier-config/tree/e21bb11d90d025c2310ce7c733bc780775ec8664)
- [chore(git): add gitignore](https://github.com/ionic-team/prettier-config/commit/1eed9277fb38e18dbc1d6d87a21d8cc409d6e91c) 

Up for debate:
- Is this the _best_ way to version this library? We bump Prettier as `peerDependency`, which gets installed automatically on newer versions of NPM. Prettier has 'breaking changes' in some minor versions, so 🤷 IDK