### PR TITLE
chore(deps): update peerdep for prettier to include v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/prettier-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Prettier config for Ionic and Capacitor",
   "keywords": [],
   "homepage": "https://github.com/ionic-team/prettier-config#readme",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "index.js"
   ],
   "peerDependencies": {
-    "prettier": "^2.4.0"
+    "prettier": "^2.4.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
This updates the peer dependency version specifier for `prettier` to include v3.0.0, which [was released last week](https://prettier.io/blog/2023/07/05/3.0.0.html)

I'm not sure how much testing we do. I did an `npm pack` locally and was able to install this alongside `prettier@3.0.0` in the main Stencil repo without issues.